### PR TITLE
Reduce Warning Spam

### DIFF
--- a/ECOv003_L2T_STARS/VIIRS/VNP09GA.py
+++ b/ECOv003_L2T_STARS/VIIRS/VNP09GA.py
@@ -1246,7 +1246,7 @@ class VNP09GA:
         if len(granules) == 0:
             return None
 
-        if len(granules) > 0:
+        if len(granules) > 1:
             logger.warning("Found more VIIRS granules than expected")
 
         self.add_granules(granules)


### PR DESCRIPTION
Another backport of a Collection 2 fix, this one fixes warning spam about 'Found more VIIRS granules than expected'.