### PR TITLE
Fix a missing import of LPDAACServerUnreachable

### DIFF
--- a/ECOv003_L2T_STARS/L2T_STARS.py
+++ b/ECOv003_L2T_STARS/L2T_STARS.py
@@ -24,6 +24,8 @@ from harmonized_landsat_sentinel import (
     CMR_SEARCH_URL
 )
 
+from .LPDAAC.LPDAACDataPool import LPDAACServerUnreachable
+
 from ECOv003_exit_codes import *
 
 from ECOv002_granules import L2TLSTE


### PR DESCRIPTION
Looks like this line was removed on accident as part of import cleaning.