### PR TITLE
Fix L2T_STARS to load L2T_LSTE from Collection 3 granules

### DIFF
--- a/ECOv003_L2T_STARS/L2T_STARS.py
+++ b/ECOv003_L2T_STARS/L2T_STARS.py
@@ -28,7 +28,7 @@ from .LPDAAC.LPDAACDataPool import LPDAACServerUnreachable
 
 from ECOv003_exit_codes import *
 
-from ECOv002_granules import L2TLSTE
+from ECOv003_granules import L2TLSTE
 import urllib
 
 from .version import __version__


### PR DESCRIPTION
Fix L2T_STARS.py to load inputs as Collection 3 inputs, not Collection 2 inputs.

Not having this change was causing crashes when loading Collection 3 inputs that are missing the BuildID in the filename.