### PR TITLE
Fix exception handling code for HLS_connection.listing

### DIFF
--- a/ECOv003_L2T_STARS/L2T_STARS.py
+++ b/ECOv003_L2T_STARS/L2T_STARS.py
@@ -353,7 +353,7 @@ def L2T_STARS(
         except Exception as e:
             logger.exception(e)
             raise AuxiliaryServerUnreachable(
-                f"Unable to scan Harmonized Landsat Sentinel server: {HLS_connection.remote}"
+                f"Unable to scan Harmonized Landsat Sentinel server: {CMR_SEARCH_URL}"
             )
 
         # Check for missing HLS Sentinel data


### PR DESCRIPTION
`.remote` was removed as a parameter from HLS2_connection, and so we can't use that value when logging a failure.